### PR TITLE
The PhotometricSystem d.mid is the same for all filters within

### DIFF
--- a/python/scripts/photdm.2MASS.2MASS.H.xml
+++ b/python/scripts/photdm.2MASS.2MASS.H.xml
@@ -1,6 +1,6 @@
 <!-- XML serialization of Photometry Filter -->
 <!-- Photometric System -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_2MASS_H">
+<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_2MASS">
   <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
     value="2MASS" />
   <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"


### PR DESCRIPTION
The PhotometricSystem dmid should be the same for all Filters belonging to it : 
therefore I propose to remove the _H in the  Photsystem dmid : 
all 2MASS filters belong to the 2MASS PhotometricSystem unless you create a new PhotSys for your data and your specific Filter.